### PR TITLE
Fix bug in clip editor when getting files for display on macOS

### DIFF
--- a/TikTok Client/clientUI.py
+++ b/TikTok Client/clientUI.py
@@ -379,9 +379,9 @@ class clipEditor(QMainWindow):
         self.updateClipDuration()
         self.mediaPlayer.stop()
         if len(mp4file.split("/")) > 2:
-            self.mediaPlayer.setMedia(QMediaContent(QUrl.fromLocalFile(f'{mp4file}')));
+            self.mediaPlayer.setMedia(QMediaContent(QUrl.fromLocalFile(f'{current_path}/{mp4file}')));
         else:
-            self.mediaPlayer.setMedia(QMediaContent(QUrl.fromLocalFile(f'TempClips/{mp4file}.mp4')))
+            self.mediaPlayer.setMedia(QMediaContent(QUrl.fromLocalFile(f'{current_path}/TempClips/{mp4file}.mp4')))
         self.mediaPlayer.setVolume(audio * 100)
         self.estTime.setText(str(self.videoWrapper.scriptWrapper.getEstimatedVideoTime()))
         self.videoLength.setText(f'{round(video_duration, 1)}')


### PR DESCRIPTION
Files that were in the TempClips directory could not be displayed by the media player in the clip editor.
This uses the current path variable when passing clips to the media player to pass the full path to the file.